### PR TITLE
Feat 102 themes remake

### DIFF
--- a/app/Controllers/Http/ClientController.ts
+++ b/app/Controllers/Http/ClientController.ts
@@ -1,0 +1,31 @@
+import { HttpContextContract } from '@ioc:Adonis/Core/HttpContext'
+import { Theme } from 'App/Listeners/ThemeListener'
+import SystemMeta from 'App/Models/SystemMeta'
+import Space from 'App/Services/SpaceService'
+import { ThemeContext } from 'App/Services/ThemeContext'
+
+export default class ClientController {
+  public async index(context: HttpContextContract) {
+    const themeId = await SystemMeta.firstOrCreateMetaArray<string>('themes:active')
+
+    if (!themeId) {
+      return context.response.internalServerError({
+        message: 'Theme not defined',
+      })
+    }
+
+    const theme = await Space.emit<Theme>('theme:show', themeId[0])
+
+    if (!theme) {
+      return context.response.internalServerError({
+        message: 'Theme not found',
+      })
+    }
+
+    const { render } = await import(theme.filename)
+
+    const themeContext = await ThemeContext.mount(context)
+
+    return render(themeContext)
+  }
+}

--- a/app/Controllers/Http/ClientController.ts
+++ b/app/Controllers/Http/ClientController.ts
@@ -8,7 +8,7 @@ export default class ClientController {
   public async index(context: HttpContextContract) {
     const themeId = await SystemMeta.firstOrCreateMetaArray<string>('themes:active')
 
-    if (!themeId) {
+    if (!themeId.length) {
       return context.response.internalServerError({
         message: 'Theme not defined',
       })

--- a/app/Controllers/Http/PagesController.ts
+++ b/app/Controllers/Http/PagesController.ts
@@ -1,0 +1,42 @@
+import { pick } from 'lodash'
+
+import { HttpContextContract } from '@ioc:Adonis/Core/HttpContext'
+import Drive from '@ioc:Adonis/Core/Drive'
+
+import { Page } from 'App/Listeners/PageListener'
+import Space from 'App/Services/SpaceService'
+
+export default class PagesController {
+  public async index() {
+    const pages = await Space.emit<Page[]>('page:index')
+
+    return {
+      meta: { total: pages?.length },
+      data: pages?.map((p) => pick(p, ['id', 'title'])),
+    }
+  }
+
+  public async show({ params, response }: HttpContextContract) {
+    const page = await Space.emit<Page>('page:show', Number(params.id))
+
+    if (!page) {
+      return response.notFound({
+        message: 'Page not found',
+      })
+    }
+
+    const exist = await Drive.exists(page.filename)
+
+    if (!exist) {
+      return response.notFound({
+        message: 'Page not found',
+      })
+    }
+
+    const content = await Drive.get(page.filename)
+
+    response.type('js')
+
+    return content.toString()
+  }
+}

--- a/app/Controllers/Http/ThemeController.ts
+++ b/app/Controllers/Http/ThemeController.ts
@@ -38,12 +38,6 @@ export default class ThemeController {
   }
 
   public async update({ request, params }: HttpContextContract) {
-    const theme = await Space.emit<Theme>('theme:show', params.id)
-
-    if (!theme) {
-      throw new Error('Theme not found')
-    }
-
     const { active } = await request.validate({
       schema: schema.create({
         active: schema.boolean(),
@@ -51,12 +45,12 @@ export default class ThemeController {
     })
 
     await Space.emit('theme:update', {
-      name: theme.name,
+      id: params.id,
       active,
     })
 
     return {
-      message: 'Current theme updated',
+      message: 'Theme updated',
     }
   }
 }

--- a/app/Helpers/index.ts
+++ b/app/Helpers/index.ts
@@ -38,9 +38,12 @@ export async function readIfExist(path: string) {
 }
 
 export async function isGitUrl(url: string) {
-  return execa('git', ['ls-remote', url])
-    .catch(() => false)
-    .then(() => true)
+  try {
+    await execa('git', ['ls-remote', url])
+    return true
+  } catch (error) {
+    return false
+  }
 }
 
 export async function listFolder(path: string): Promise<string[]> {

--- a/app/Helpers/index.ts
+++ b/app/Helpers/index.ts
@@ -1,5 +1,8 @@
 import execa from 'execa'
 import fs from 'fs'
+import path from 'path'
+
+import Drive from '@ioc:Adonis/Core/Drive'
 
 import Logger from '@ioc:Adonis/Core/Logger'
 
@@ -21,23 +24,23 @@ export function requireIfExist(path: string) {
 }
 
 export async function importIfExist(path: string) {
-  try {
-    const file = await import(path)
+  return import(path).then((m) => m.default).catch(() => null)
+}
 
-    return file.default || file
-  } catch (error) {
-    Logger.error(error)
-    return null
+export async function readIfExist(path: string) {
+  const exists = await Drive.exists(path)
+
+  if (exists) {
+    return fs.readFileSync(path, 'utf8')
   }
+
+  return null
 }
 
 export async function isGitUrl(url: string) {
-  try {
-    await execa('git', ['ls-remote', url])
-    return true
-  } catch (error) {
-    return false
-  }
+  return execa('git', ['ls-remote', url])
+    .catch(() => false)
+    .then(() => true)
 }
 
 export async function listFolder(path: string): Promise<string[]> {
@@ -48,4 +51,14 @@ export async function listFolder(path: string): Promise<string[]> {
       Logger.error(error)
       return []
     })
+}
+
+export async function findConfig(folderPath: string) {
+  const jsonConfig = await readIfExist(path.join(folderPath, 'space.config.json'))
+
+  if (jsonConfig && isJson(jsonConfig)) {
+    return JSON.parse(jsonConfig)
+  }
+
+  return {}
 }

--- a/app/Listeners/CommentListener.ts
+++ b/app/Listeners/CommentListener.ts
@@ -1,4 +1,6 @@
 import { validator } from '@ioc:Adonis/Core/Validator'
+import { string } from '@ioc:Adonis/Core/Helpers'
+
 import CommentIndexValidator from 'App/Validators/CommentIndexValidator'
 import Comment from 'App/Models/Comment'
 import CommentStoreValidator from 'App/Validators/CommentStoreValidator'
@@ -14,7 +16,10 @@ export default class CommentListener {
 
     const query = Comment.query()
 
-    query.orderBy(filters.orderBy || 'created_at', filters.orderDesc ? 'desc' : 'asc')
+    query.orderBy(
+      string.snakeCase(filters.orderBy || 'created_at'),
+      filters.orderDesc ? 'desc' : 'asc'
+    )
 
     const result = await query.paginate(filters.page || 1, filters.limit)
 

--- a/app/Listeners/ImageListener.ts
+++ b/app/Listeners/ImageListener.ts
@@ -1,4 +1,5 @@
 import { validator } from '@ioc:Adonis/Core/Validator'
+import { string } from '@ioc:Adonis/Core/Helpers'
 import Image from 'App/Models/Image'
 import ImageIndexValidator from 'App/Validators/ImageIndexValidator'
 import ImageShowValidator from 'App/Validators/ImageShowValidator'
@@ -18,7 +19,10 @@ export default class ImageListener {
       query.select(filters.fields)
     }
 
-    query.orderBy(filters.orderBy || 'created_at', filters.orderDesc ? 'desc' : 'asc')
+    query.orderBy(
+      string.snakeCase(filters.orderBy || 'created_at'),
+      filters.orderDesc ? 'desc' : 'asc'
+    )
 
     const result = await query.paginate(filters.page || 1, filters.limit)
 
@@ -34,7 +38,7 @@ export default class ImageListener {
     const query = Image.query()
 
     if (filters.fields) {
-      query.select(filters.fields)
+      query.select(filters.fields.map(string.snakeCase))
     }
 
     const image = await query.where('id', filters.id).firstOrFail()

--- a/app/Listeners/PageListener.ts
+++ b/app/Listeners/PageListener.ts
@@ -1,0 +1,49 @@
+import Space from 'App/Services/SpaceService'
+import { Theme } from './ThemeListener'
+
+export interface Page {
+  id: number
+  title: string
+  filename: string
+}
+
+const pages: Page[] = []
+
+export default class PageListener {
+  public async index() {
+    if (pages.length) {
+      return pages
+    }
+
+    const themes = await Space.emit<Theme[]>('theme:index')
+
+    if (!themes) {
+      return pages
+    }
+
+    themes
+      .filter((theme) => theme.active)
+      .map((theme) =>
+        (theme.dashboard?.pages || []).map((page) => ({
+          ...page,
+          filename: theme.makePath(page.path),
+        }))
+      )
+      .reduce((all, current) => all.concat(current), [])
+      .forEach((page) => {
+        pages.push({
+          id: pages.length,
+          title: page.title,
+          filename: page.filename,
+        })
+      })
+
+    return pages
+  }
+
+  public async show(id: number) {
+    const pages = await this.index()
+
+    return pages.find((page) => page.id === id)
+  }
+}

--- a/app/Listeners/ThemeListener.ts
+++ b/app/Listeners/ThemeListener.ts
@@ -11,12 +11,22 @@ import Content from 'App/Services/ContentService'
 import { findConfig, isGitUrl } from 'App/Helpers'
 import ThemeConfigValidator from 'App/Validators/ThemeConfigValidator'
 
+interface ThemePage {
+  title: string
+  path: string
+}
 export interface Theme {
   id: string
   name: string
   active: boolean
   description?: string
-  scripts?: Record<string, string>
+  author?: {
+    name: string
+    email: string
+  }
+  dashboard?: {
+    pages: ThemePage[]
+  }
   filename: string
   makePath: (...args: string[]) => string
 }
@@ -43,7 +53,7 @@ export default class ThemeListener {
 
           const config = await findConfig(theme.filename)
 
-          Object.assign(theme, pick(config, ['name', 'description']))
+          Object.assign(theme, pick(config, ['name', 'description', 'dashboard']))
 
           return theme
         })
@@ -134,21 +144,21 @@ export default class ThemeListener {
     await SystemMeta.updateOrCreateMetaArray('themes:active', uniq([...activeThemes, id]))
   }
 
-  public async runScript(data: { name: string; script: string }) {
-    const theme = await this.show(data.name)
+  // public async runScript(data: { name: string; script: string }) {
+  //   const theme = await this.show(data.name)
 
-    if (!theme) {
-      throw new Error('Theme not found')
-    }
+  //   if (!theme) {
+  //     throw new Error('Theme not found')
+  //   }
 
-    if (!theme.scripts || !theme.scripts[data.script]) {
-      throw new Error('Theme script not found')
-    }
+  //   if (!theme.scripts || !theme.scripts[data.script]) {
+  //     throw new Error('Theme script not found')
+  //   }
 
-    const [file, ...args] = theme.scripts[data.script].split(' ')
+  //   const [file, ...args] = theme.scripts[data.script].split(' ')
 
-    await execa(file, args, {
-      cwd: theme.filename,
-    })
-  }
+  //   await execa(file, args, {
+  //     cwd: theme.filename,
+  //   })
+  // }
 }

--- a/app/Listeners/VideoListener.ts
+++ b/app/Listeners/VideoListener.ts
@@ -1,4 +1,5 @@
 import { validator } from '@ioc:Adonis/Core/Validator'
+import { string } from '@ioc:Adonis/Core/Helpers'
 import Video from 'App/Models/Video'
 import VideoIndexValidator from 'App/Validators/VideoIndexValidator'
 import VideoShowValidator from 'App/Validators/VideoShowValidator'
@@ -15,7 +16,7 @@ export default class VideoListener {
     const query = Video.query()
 
     if (filters.fields) {
-      query.select([...filters.fields, 'id'].map((f) => `videos.${f}`))
+      query.select(filters.fields.map(string.snakeCase))
     }
 
     if (filters.include?.includes('images')) {
@@ -30,7 +31,10 @@ export default class VideoListener {
       query.preload('comments')
     }
 
-    query.orderBy(filters.orderBy || 'created_at', filters.orderDesc ? 'desc' : 'asc')
+    query.orderBy(
+      string.snakeCase(filters.orderBy || 'created_at'),
+      filters.orderDesc ? 'desc' : 'asc'
+    )
 
     const result = await query.paginate(filters.page || 1, filters.limit)
 
@@ -46,7 +50,7 @@ export default class VideoListener {
     const query = Video.query()
 
     if (filters.fields) {
-      query.select(filters.fields)
+      query.select(filters.fields.map(string.snakeCase))
     }
 
     const video = await query.where('id', filters.id).firstOrFail()

--- a/app/Listeners/ViewListener.ts
+++ b/app/Listeners/ViewListener.ts
@@ -1,4 +1,5 @@
 import { validator } from '@ioc:Adonis/Core/Validator'
+import { string } from '@ioc:Adonis/Core/Helpers'
 import View from 'App/Models/View'
 import ViewIndexValidator from 'App/Validators/ViewIndexValidator'
 import ViewShowValidator from 'App/Validators/ViewShowValidator'
@@ -15,10 +16,12 @@ export default class ViewListener {
     const query = View.query()
 
     if (filters.fields) {
-      query.select(filters.fields)
+      query.select(filters.fields.map(string.snakeCase))
     }
-
-    query.orderBy(filters.orderBy || 'created_at', filters.orderDesc ? 'desc' : 'asc')
+    query.orderBy(
+      string.snakeCase(filters.orderBy || 'created_at'),
+      filters.orderDesc ? 'desc' : 'asc'
+    )
 
     const pagination = await query.paginate(filters.page || 1, filters.limit || 20)
 

--- a/app/Models/Video.ts
+++ b/app/Models/Video.ts
@@ -1,10 +1,21 @@
 import { DateTime } from 'luxon'
-import { BaseModel, beforeDelete, column, HasMany, hasMany } from '@ioc:Adonis/Lucid/Orm'
+import {
+  BaseModel,
+  beforeDelete,
+  BelongsTo,
+  belongsTo,
+  column,
+  HasMany,
+  hasMany,
+  ModelQueryBuilderContract,
+  scope,
+} from '@ioc:Adonis/Lucid/Orm'
 import Env from '@ioc:Adonis/Core/Env'
 import Drive from '@ioc:Adonis/Core/Drive'
 import Image from './Image'
 import View from './View'
 import Comment from './Comment'
+import Visibility from './Visibility'
 
 function serializeSrc({ source, src, id }: Video) {
   if (source === 'local') {
@@ -61,6 +72,17 @@ export default class Video extends BaseModel {
 
   @hasMany(() => Comment)
   public comments: HasMany<typeof Comment>
+
+  @belongsTo(() => Visibility)
+  public visibility: BelongsTo<typeof Visibility>
+
+  public static havePermissions = scope(
+    (query: ModelQueryBuilderContract<typeof Video>, permissions: string[]) => {
+      query.whereHas('visibility', (q) =>
+        q.whereHas('permissions', (q) => q.whereIn('name', permissions)).orWhere('name', 'public')
+      )
+    }
+  )
 
   @beforeDelete()
   public static async deleteFile(video: Video) {

--- a/app/Services/SpaceService.ts
+++ b/app/Services/SpaceService.ts
@@ -18,12 +18,11 @@ interface Observer {
 }
 
 export class SpaceService {
-  private observers: Observer[] = []
-  private onAnyObservers: OnAnyCallback[] = []
-  private events: Map<string, Handler> = new Map()
+  public observers: Observer[] = []
+  public onAnyObservers: OnAnyCallback[] = []
+  public events: Map<string, Handler> = new Map()
 
   constructor() {
-    global.space = this
     Logger.info('[space] service started')
   }
 

--- a/app/Services/ThemeContext.ts
+++ b/app/Services/ThemeContext.ts
@@ -1,0 +1,38 @@
+import { HttpContextContract } from '@ioc:Adonis/Core/HttpContext'
+import User from 'App/Models/User'
+import Space from './SpaceService'
+import { UserSpace } from './UserSpace'
+
+export class ThemeContext {
+  private user?: ReturnType<User['serialize']>
+  public response: HttpContextContract['response']
+  public space: UserSpace
+  public path: string
+  public fullPath: string
+  public query: Record<string, any>
+
+  public static async mount({ auth, request, response }: HttpContextContract) {
+    const instance = new this()
+    instance.user = auth.user?.serialize()
+    instance.response = response
+    instance.path = request.url()
+    instance.fullPath = request.url(true)
+    instance.query = request.qs()
+
+    await instance.setSpace()
+
+    return instance
+  }
+
+  private async setSpace() {
+    const allEvents = Array.from(Space.events.keys())
+    const allowedEvents: string[] = []
+    const isAdmin = await this.user?.haveRoles(['admin'])
+
+    if (isAdmin) {
+      allowedEvents.push(...allEvents)
+    }
+
+    this.space = new UserSpace(allowedEvents)
+  }
+}

--- a/app/Services/ThemeContext.ts
+++ b/app/Services/ThemeContext.ts
@@ -1,10 +1,10 @@
 import { HttpContextContract } from '@ioc:Adonis/Core/HttpContext'
-import User from 'App/Models/User'
+
 import Space from './SpaceService'
 import { UserSpace } from './UserSpace'
 
 export class ThemeContext {
-  private user?: ReturnType<User['serialize']>
+  public user?: Record<string, any>
   public response: HttpContextContract['response']
   public space: UserSpace
   public path: string

--- a/app/Services/ThemeContext.ts
+++ b/app/Services/ThemeContext.ts
@@ -26,12 +26,7 @@ export class ThemeContext {
 
   private async setSpace() {
     const allEvents = Array.from(Space.events.keys())
-    const allowedEvents: string[] = []
-    const isAdmin = await this.user?.haveRoles(['admin'])
-
-    if (isAdmin) {
-      allowedEvents.push(...allEvents)
-    }
+    const allowedEvents: string[] = allEvents
 
     this.space = new UserSpace(allowedEvents)
   }

--- a/app/Services/UserSpace.ts
+++ b/app/Services/UserSpace.ts
@@ -1,0 +1,12 @@
+import Space from './SpaceService'
+
+export class UserSpace {
+  constructor(private allowEvents: string[] = []) {}
+
+  public emit(event: string, data: any) {
+    if (!this.allowEvents.includes(event)) {
+      throw new Error(`Event ${event} is not allowed for user`)
+    }
+    return Space.emit(event, data)
+  }
+}

--- a/app/Validators/CommentIndexValidator.ts
+++ b/app/Validators/CommentIndexValidator.ts
@@ -1,8 +1,7 @@
 import { schema, rules } from '@ioc:Adonis/Core/Validator'
-import { string } from '@ioc:Adonis/Core/Helpers'
 import Comment from 'App/Models/Comment'
 
-const columns = Array.from(Comment.$columnsDefinitions.keys()).map(string.snakeCase)
+const columns = Array.from(Comment.$columnsDefinitions.keys())
 
 export default class CommentIndexValidator {
   public schema = schema.create({

--- a/app/Validators/ImageIndexValidator.ts
+++ b/app/Validators/ImageIndexValidator.ts
@@ -1,8 +1,7 @@
 import { schema, rules } from '@ioc:Adonis/Core/Validator'
-import { string } from '@ioc:Adonis/Core/Helpers'
 import Image from 'App/Models/Image'
 
-const columns = Array.from(Image.$columnsDefinitions.keys()).map(string.snakeCase)
+const columns = Array.from(Image.$columnsDefinitions.keys())
 export default class ImageIndexValidator {
   constructor() {}
 

--- a/app/Validators/ImageShowValidator.ts
+++ b/app/Validators/ImageShowValidator.ts
@@ -1,8 +1,7 @@
 import { schema } from '@ioc:Adonis/Core/Validator'
-import { string } from '@ioc:Adonis/Core/Helpers'
 import Image from 'App/Models/Image'
 
-const columns = Array.from(Image.$columnsDefinitions.keys()).map(string.snakeCase)
+const columns = Array.from(Image.$columnsDefinitions.keys())
 
 export default class ImageShowValidator {
   public schema = schema.create({

--- a/app/Validators/ThemeConfigValidator.ts
+++ b/app/Validators/ThemeConfigValidator.ts
@@ -1,0 +1,23 @@
+import { schema } from '@ioc:Adonis/Core/Validator'
+
+export default class ThemeConfigValidator {
+  public schema = schema.create({
+    name: schema.string(),
+    author: schema.object.optional().members({
+      name: schema.string(),
+      email: schema.string.optional(),
+    }),
+    screenshots: schema.object.optional().members({
+      desktop: schema.string(),
+      mobile: schema.string.optional(),
+    }),
+    dashboard: schema.object.optional().members({
+      pages: schema.array.optional().members(
+        schema.object().members({
+          title: schema.string(),
+          path: schema.string(),
+        })
+      ),
+    }),
+  })
+}

--- a/app/Validators/VideoIndexValidator.ts
+++ b/app/Validators/VideoIndexValidator.ts
@@ -1,9 +1,8 @@
 import { schema, rules } from '@ioc:Adonis/Core/Validator'
-import { string } from '@ioc:Adonis/Core/Helpers'
 
 import Video from 'App/Models/Video'
 
-const columns = Array.from(Video.$columnsDefinitions.keys()).map(string.snakeCase)
+const columns = Array.from(Video.$columnsDefinitions.keys())
 
 export default class VideoIndexValidator {
   public schema = schema.create({

--- a/app/Validators/ViewIndexValidator.ts
+++ b/app/Validators/ViewIndexValidator.ts
@@ -1,8 +1,7 @@
 import { schema, rules } from '@ioc:Adonis/Core/Validator'
-import { string } from '@ioc:Adonis/Core/Helpers'
 import View from 'App/Models/View'
 
-const columns = Array.from(View.$columnsDefinitions.keys()).map(string.snakeCase)
+const columns = Array.from(View.$columnsDefinitions.keys())
 
 export default class ViewIndexValidator {
   public schema = schema.create({

--- a/start/routes/client.ts
+++ b/start/routes/client.ts
@@ -1,0 +1,3 @@
+import Route from '@ioc:Adonis/Core/Route'
+
+Route.get('*', 'ClientController.index')

--- a/start/routes/index.ts
+++ b/start/routes/index.ts
@@ -9,3 +9,5 @@ const files = listDirectoryFiles(__dirname, Application.appRoot, [
 files.forEach((file) => {
   require(Application.makePath(file))
 })
+
+import './client'

--- a/start/routes/pages.ts
+++ b/start/routes/pages.ts
@@ -1,0 +1,9 @@
+import Route from '@ioc:Adonis/Core/Route'
+
+Route.group(() => {
+  Route.resource('pages', 'PagesController').only(['index', 'show'])
+})
+  .prefix('v1')
+  .prefix('api')
+  .middleware('auth')
+  .middleware('acl:admin')

--- a/start/routes/videos.ts
+++ b/start/routes/videos.ts
@@ -1,11 +1,16 @@
 import Route from '@ioc:Adonis/Core/Route'
 
 Route.group(() => {
-  Route.post('/videos/upload', 'VideosController.upload')
+  Route.post('/videos/upload', 'VideosController.upload').middleware(['auth', 'acl:admin'])
+
   Route.get('/videos/embed/:id', 'VideosController.embed')
-  Route.resource('videos', 'VideosController').only(['index', 'show', 'store', 'update', 'destroy'])
+  Route.resource('videos', 'VideosController')
+    .only(['index', 'show', 'store', 'update', 'destroy'])
+    .middleware({
+      store: ['auth', 'acl:admin'],
+      update: ['auth', 'acl:admin'],
+      destroy: ['auth', 'acl:admin'],
+    })
 })
   .prefix('v1')
   .prefix('api')
-  .middleware('auth')
-  .middleware('acl:admin')

--- a/tests/PageListener.int.test.ts
+++ b/tests/PageListener.int.test.ts
@@ -1,0 +1,51 @@
+import test from 'japa'
+import fs from 'fs'
+
+import Drive from '@ioc:Adonis/Core/Drive'
+import Content from 'App/Services/ContentService'
+import Space from 'App/Services/SpaceService'
+import SystemMeta from 'App/Models/SystemMeta'
+import { Page } from 'App/Listeners/PageListener'
+
+test.group('PageListener (int)', (group) => {
+  const pages = [
+    {
+      title: 'teste',
+      path: 'teste.js',
+    },
+  ]
+
+  const json = JSON.stringify({ dashboard: { pages } })
+
+  const filename = Content.makePath('themes', 'test-theme', 'space.config.json')
+
+  group.before(async () => {
+    await Drive.put(filename, json)
+    await SystemMeta.updateOrCreateMetaArray('themes:active', ['test-theme'])
+  })
+  group.after(async () => {
+    await fs.promises.rmdir(Content.makePath('themes', 'test-theme'), { recursive: true })
+    await SystemMeta.query().delete()
+  })
+
+  test('[page:index] should return a list of pages', async (assert) => {
+    const result = await Space.emit<Page[]>('page:index')
+
+    assert.deepEqual(result, [
+      {
+        id: 0,
+        title: 'teste',
+        filename: Content.makePath('themes', 'test-theme', 'teste.js'),
+      },
+    ])
+  })
+  test('[page:show] should return a page by id', async (assert) => {
+    const result = await Space.emit<Page>('page:show', 0)
+
+    assert.deepEqual(result, {
+      id: 0,
+      title: 'teste',
+      filename: Content.makePath('themes', 'test-theme', 'teste.js'),
+    })
+  })
+})

--- a/tests/ThemeListener.int.test.ts
+++ b/tests/ThemeListener.int.test.ts
@@ -15,7 +15,7 @@ async function createFakeTheme(name: string) {
 }
 
 test.group('ThemeListener (int)', (group) => {
-  group.afterEach(async () => {
+  group.beforeEach(async () => {
     const themes = await listFolder(Content.makePath('themes'))
 
     await Promise.all(
@@ -28,9 +28,9 @@ test.group('ThemeListener (int)', (group) => {
   })
 
   test('[theme:index] should return list of themes', async (assert) => {
-    const name = string.dashCase(faker.name.title())
+    const id = string.dashCase(faker.name.title())
 
-    await createFakeTheme(name)
+    await createFakeTheme(id)
 
     const themes = await Space.emit<Theme[]>('theme:index')
 
@@ -39,22 +39,22 @@ test.group('ThemeListener (int)', (group) => {
       return
     }
 
-    assert.equal(themes[0].name, name)
+    assert.equal(themes[0].id, id)
   })
 
-  test('[theme:show] should return a theme by name', async (assert) => {
-    const name = string.dashCase(faker.name.title())
+  test('[theme:show] should return a theme by id', async (assert) => {
+    const id = string.dashCase(faker.name.title())
 
-    await createFakeTheme(name)
+    await createFakeTheme(id)
 
-    const theme = await Space.emit<Theme>('theme:show', name)
+    const theme = await Space.emit<Theme>('theme:show', id)
 
     if (!theme) {
       assert.fail('event should return a value')
       return
     }
 
-    assert.equal(theme.name, name)
+    assert.equal(theme.id, id)
   })
 
   test('[theme:store] should download a theme', async (assert) => {
@@ -67,7 +67,7 @@ test.group('ThemeListener (int)', (group) => {
       return
     }
 
-    assert.equal(theme.name, 'awake-theme')
+    assert.equal(theme.id, 'awake-theme')
   })
 
   test('[theme:store] should throw a error when is a invalid git url', async (assert) => {


### PR DESCRIPTION
## Fixes
- fix #102 

## Changes
  - Add Theme context class to handle communication between themes and the app
  - Add `findConfig()` helper that is a function to search for `space.config.json` in a foler path.
  - Recreate page listener and controller but with runtime-pages only now
  - Validate theme config and files on start theme
  - Add page listener tests
